### PR TITLE
전체 회고 조회 API Controller 생성, Rest Docs 문서 adoc 파일 생성

### DIFF
--- a/src/main/java/commaproject/be/commaserver/controller/CommaController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/CommaController.java
@@ -1,8 +1,9 @@
 package commaproject.be.commaserver.controller;
 
 import commaproject.be.commaserver.common.BaseResponse;
-import commaproject.be.commaserver.service.dto.CommaDetailResponse;
 import commaproject.be.commaserver.service.CommaService;
+import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,5 +19,11 @@ public class CommaController {
     public BaseResponse<CommaDetailResponse> readOne(@PathVariable Long commaId) {
         CommaDetailResponse commaDetailResponse = commaService.readOne(commaId);
         return new BaseResponse<>("200", "OK", commaDetailResponse);
+    }
+
+    @GetMapping("/api/commas")
+    public BaseResponse<List<CommaDetailResponse>> readAll() {
+        List<CommaDetailResponse> commaDetailResponses = commaService.readAll();
+        return new BaseResponse<>("200", "OK", commaDetailResponses);
     }
 }

--- a/src/main/java/commaproject/be/commaserver/service/CommaService.java
+++ b/src/main/java/commaproject/be/commaserver/service/CommaService.java
@@ -1,12 +1,17 @@
 package commaproject.be.commaserver.service;
 
 import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CommaService {
 
     public CommaDetailResponse readOne(Long commaId) {
+        return null;
+    }
+
+    public List<CommaDetailResponse> readAll() {
         return null;
     }
 }


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #7 


<br><br>

### 📝 구현 내용

- 전체 회고 조회 API 컨트롤러 추가
- `mocking` 할 service 메서드 추가
- `rest docs` API 문서를 위한 테스트 코드 추가
