### PR TITLE
회고 생성 컨트롤러 추가, 회고 생성 Rest Docs adoc 파일 생성

### DIFF
--- a/src/main/java/commaproject/be/commaserver/controller/CommaController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/CommaController.java
@@ -3,10 +3,14 @@ package commaproject.be.commaserver.controller;
 import commaproject.be.commaserver.common.BaseResponse;
 import commaproject.be.commaserver.service.CommaService;
 import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import commaproject.be.commaserver.service.dto.CommaRequest;
+import commaproject.be.commaserver.service.dto.CommaResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,5 +29,11 @@ public class CommaController {
     public BaseResponse<List<CommaDetailResponse>> readAll() {
         List<CommaDetailResponse> commaDetailResponses = commaService.readAll();
         return new BaseResponse<>("200", "OK", commaDetailResponses);
+    }
+
+    @PostMapping("/api/commas")
+    public BaseResponse<CommaResponse> update(@RequestBody CommaRequest commaRequest) {
+        CommaResponse commaResponse = commaService.create(commaRequest);
+        return new BaseResponse<>("200", "OK", commaResponse);
     }
 }

--- a/src/main/java/commaproject/be/commaserver/service/CommaService.java
+++ b/src/main/java/commaproject/be/commaserver/service/CommaService.java
@@ -1,6 +1,8 @@
 package commaproject.be.commaserver.service;
 
 import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import commaproject.be.commaserver.service.dto.CommaRequest;
+import commaproject.be.commaserver.service.dto.CommaResponse;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +14,10 @@ public class CommaService {
     }
 
     public List<CommaDetailResponse> readAll() {
+        return null;
+    }
+
+    public CommaResponse create(CommaRequest commaRequest) {
         return null;
     }
 }

--- a/src/main/java/commaproject/be/commaserver/service/dto/CommaRequest.java
+++ b/src/main/java/commaproject/be/commaserver/service/dto/CommaRequest.java
@@ -1,0 +1,18 @@
+package commaproject.be.commaserver.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class CommaRequest {
+
+    private String title;
+    private String content;
+    private String username;
+    private Long userId;
+}

--- a/src/main/java/commaproject/be/commaserver/service/dto/CommaResponse.java
+++ b/src/main/java/commaproject/be/commaserver/service/dto/CommaResponse.java
@@ -1,0 +1,11 @@
+package commaproject.be.commaserver.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommaResponse {
+
+    private Long id;
+}

--- a/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
@@ -18,7 +18,9 @@ import commaproject.be.commaserver.common.BaseResponse;
 import commaproject.be.commaserver.controller.CommaController;
 import commaproject.be.commaserver.service.CommaService;
 import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import commaproject.be.commaserver.service.dto.CommaRequest;
 import commaproject.be.commaserver.service.dto.CommentResponse;
+import commaproject.be.commaserver.service.dto.CommaResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -161,6 +163,42 @@ class CommaControllerTest {
                         fieldWithPath("data[].comments[].username").type(JsonFieldType.STRING).description("댓글 작성자"),
                         fieldWithPath("data[].comments[].userId").type(JsonFieldType.NUMBER).description("댓글 작성자 아이디"),
                         fieldWithPath("data[].comments[].content").type(JsonFieldType.STRING).description("댓글 내용")
+                    )
+                ));
+    }
+
+    @Test
+    @DisplayName("회고 생성 성공")
+    void create_comma_success() throws Exception {
+
+        // given
+        Long userId = 1L;
+        CommaRequest commaRequest = new CommaRequest("title1", "content1", "username1", userId);
+        CommaResponse createResponse = new CommaResponse(commaRequest.getUserId());
+
+        when(commaService.create(commaRequest)).thenReturn(createResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.post("/api/commas")
+                .content(objectMapper
+                    .writeValueAsString(commaRequest))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "comma-post",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("생성된 회고 아이디")
                     )
                 ));
     }


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #8


<br><br>

### 📝 구현 내용

- 회고 생성 컨트롤러 추가
- `mocking` 하기 위한 service 메서드 추가
- 요청을 받기 위한 DTO 와 응답해줄 DTO 클래스 추가
- Rest Docs API 문서 작성을 위한 테스트 코드 추가

<br><br>

### 💡 참고 자료

<img width="368" alt="Screen Shot 2022-12-28 at 8 59 32 PM" src="https://user-images.githubusercontent.com/73376468/209809129-a6756f7f-828a-4b16-b441-206fdbb59077.png">
