### PR TITLE
회고 수정 API 컨트롤러 추가, Rest Docs API 문서 테스트 코드 추가

### DIFF
--- a/src/main/java/commaproject/be/commaserver/controller/CommaController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/CommaController.java
@@ -1,15 +1,17 @@
 package commaproject.be.commaserver.controller;
 
 import commaproject.be.commaserver.common.BaseResponse;
-import commaproject.be.commaserver.service.CommaService;
-import commaproject.be.commaserver.service.dto.CommaDetailResponse;
-import commaproject.be.commaserver.service.dto.CommaRequest;
 import commaproject.be.commaserver.service.dto.CommaResponse;
+import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import commaproject.be.commaserver.service.CommaService;
+import commaproject.be.commaserver.service.dto.CommaRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,5 +37,11 @@ public class CommaController {
     public BaseResponse<CommaResponse> update(@RequestBody CommaRequest commaRequest) {
         CommaResponse commaResponse = commaService.create(commaRequest);
         return new BaseResponse<>("200", "OK", commaResponse);
+    }
+
+    @PutMapping("/api/commas/{commaId}")
+    public BaseResponse<CommaDetailResponse> update(@PathVariable Long commaId, @RequestBody CommaRequest commaRequest) {
+        CommaDetailResponse updateCommaDetailResponse = commaService.update(commaId, commaRequest);
+        return new BaseResponse<>("200", "OK", updateCommaDetailResponse);
     }
 }

--- a/src/main/java/commaproject/be/commaserver/service/CommaService.java
+++ b/src/main/java/commaproject/be/commaserver/service/CommaService.java
@@ -20,4 +20,8 @@ public class CommaService {
     public CommaResponse create(CommaRequest commaRequest) {
         return null;
     }
+
+    public CommaDetailResponse update(Long commaId, CommaRequest commaRequest) {
+        return null;
+    }
 }

--- a/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
@@ -203,6 +203,60 @@ class CommaControllerTest {
                 ));
     }
 
+    @Test
+    @DisplayName("회고 수정 성공")
+    void update_comma_success() throws Exception {
+
+        // given
+        Long commaId = 1L;
+        Long userId = 1L;
+        CommaRequest commaRequest = new CommaRequest("title1", "content1", "username1", userId);
+
+        List<CommentResponse> comments = new ArrayList<>();
+        comments.add(new CommentResponse(1L, "username1", 1L, "content1"));
+
+        CommaDetailResponse commaDetailResponse = new CommaDetailResponse(commaId, "title1", "content1", "username1", userId, LocalDateTime.of(2022, 12, 28, 15, 30), 1, comments);
+
+        when(commaService.update(commaId, commaRequest)).thenReturn(commaDetailResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.put("/api/commas/{commaId}", commaId)
+                .content(objectMapper
+                    .writeValueAsString(commaRequest))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "comma-update",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("commaId").description("수정된 회고 아이디")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("회고 아이디"),
+                        fieldWithPath("data.title").type(JsonFieldType.STRING).description("수정된 회고 제목"),
+                        fieldWithPath("data.content").type(JsonFieldType.STRING).description("수정된 회고 내용"),
+                        fieldWithPath("data.username").type(JsonFieldType.STRING).description("수정한 회고 작성자"),
+                        fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("수정한 회고 작성자 아이디"),
+                        fieldWithPath("data.createdAt").type(JsonFieldType.STRING).description("회고 작성된 시간"),
+                        fieldWithPath("data.likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                        fieldWithPath("data.comments[].id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
+                        fieldWithPath("data.comments[].username").type(JsonFieldType.STRING).description("댓글 작성자"),
+                        fieldWithPath("data.comments[].userId").type(JsonFieldType.NUMBER).description("댓글 작성자 아이디"),
+                        fieldWithPath("data.comments[].content").type(JsonFieldType.STRING).description("댓글 내용")
+                    )
+                ));
+    }
+
     private List<CommaDetailResponse> createTestData() {
         List<CommentResponse> comments1 = new ArrayList<>();
         comments1.add(new CommentResponse(1L, "username1", 1L, "content1"));


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #9 


<br><br>

### 📝 구현 내용

- 회고 수정 컨트롤러 추가
- `mocking` 하기 위한 service 메서드 추가
- Rest Docs API 문서를 위한 테스트 코드

<br><br>

### 💡 참고 자료

<img width="344" alt="Screen Shot 2022-12-28 at 9 09 41 PM" src="https://user-images.githubusercontent.com/73376468/209810433-fa255d34-e123-4746-9e0e-c84b220df4e0.png">

