### PR TITLE
회고 삭제 API 컨트롤러 추가, Rest Docs 문서 adoc 파일 생성

### DIFF
--- a/src/main/java/commaproject/be/commaserver/controller/CommaController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/CommaController.java
@@ -44,4 +44,10 @@ public class CommaController {
         CommaDetailResponse updateCommaDetailResponse = commaService.update(commaId, commaRequest);
         return new BaseResponse<>("200", "OK", updateCommaDetailResponse);
     }
+
+    @DeleteMapping("/api/commas/{commaId}")
+    public BaseResponse<CommaResponse> delete(@PathVariable Long commaId) {
+        CommaResponse deleteCommaResponse = commaService.delete(commaId);
+        return new BaseResponse<>("200", "OK", deleteCommaResponse);
+    }
 }

--- a/src/main/java/commaproject/be/commaserver/service/CommaService.java
+++ b/src/main/java/commaproject/be/commaserver/service/CommaService.java
@@ -24,4 +24,8 @@ public class CommaService {
     public CommaDetailResponse update(Long commaId, CommaRequest commaRequest) {
         return null;
     }
+
+    public CommaResponse delete(Long commaId) {
+        return null;
+    }
 }

--- a/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
@@ -257,6 +257,41 @@ class CommaControllerTest {
                 ));
     }
 
+    @Test
+    @DisplayName("회고 삭제 성공")
+    void delete_comma_success() throws Exception {
+
+        // given
+        Long commaId = 1L;
+        CommaResponse commaResponse = new CommaResponse(commaId);
+
+        when(commaService.delete(commaId)).thenReturn(commaResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.delete("/api/commas/{commaId}", commaId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "comma-delete",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("commaId").description("삭제할 회고 아이디")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("삭제된 회고 아이디")
+                    )
+                ));
+    }
+
     private List<CommaDetailResponse> createTestData() {
         List<CommentResponse> comments1 = new ArrayList<>();
         comments1.add(new CommentResponse(1L, "username1", 1L, "content1"));


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #10 


<br><br>

### 📝 구현 내용

- 회고 삭제 API 컨트롤러 추가
- `mocking` 을 위한 service 메서드
- Rest Docs API 문서 테스트 코드

<br><br>

### 💡 참고 자료

<img width="375" alt="Screen Shot 2022-12-28 at 9 21 43 PM" src="https://user-images.githubusercontent.com/73376468/209811501-3fbae650-6ae2-43c4-abea-43cf81bddb79.png">

