### PR TITLE
검색 API 문서 작성

### DIFF
--- a/src/main/java/commaproject/be/commaserver/controller/SearchController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/SearchController.java
@@ -4,10 +4,10 @@ package commaproject.be.commaserver.controller;
 import commaproject.be.commaserver.common.BaseResponse;
 import commaproject.be.commaserver.service.SearchService;
 import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import commaproject.be.commaserver.service.dto.SearchConditionRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,8 +17,8 @@ public class SearchController {
     private final SearchService searchService;
 
     @GetMapping("/api/commas")
-    public BaseResponse<List<CommaDetailResponse>> readSearchDate(@RequestParam String date) {
-        List<CommaDetailResponse> commaDetailResponses = searchService.readUsingDate(date);
+    public BaseResponse<List<CommaDetailResponse>> searchByCondition(SearchConditionRequest searchConditionRequest) {
+        List<CommaDetailResponse> commaDetailResponses = searchService.searchByCondition(searchConditionRequest);
         return new BaseResponse<>("200", "OK", commaDetailResponses);
     }
 }

--- a/src/main/java/commaproject/be/commaserver/controller/SearchController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/SearchController.java
@@ -1,0 +1,24 @@
+package commaproject.be.commaserver.controller;
+
+
+import commaproject.be.commaserver.common.BaseResponse;
+import commaproject.be.commaserver.service.SearchService;
+import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping("/api/commas")
+    public BaseResponse<List<CommaDetailResponse>> readSearchDate(@RequestParam String date) {
+        List<CommaDetailResponse> commaDetailResponses = searchService.readUsingDate(date);
+        return new BaseResponse<>("200", "OK", commaDetailResponses);
+    }
+}

--- a/src/main/java/commaproject/be/commaserver/service/SearchService.java
+++ b/src/main/java/commaproject/be/commaserver/service/SearchService.java
@@ -1,0 +1,13 @@
+package commaproject.be.commaserver.service;
+
+import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SearchService {
+
+    public List<CommaDetailResponse> readUsingDate(String date) {
+        return null;
+    }
+}

--- a/src/main/java/commaproject/be/commaserver/service/SearchService.java
+++ b/src/main/java/commaproject/be/commaserver/service/SearchService.java
@@ -1,13 +1,14 @@
 package commaproject.be.commaserver.service;
 
 import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import commaproject.be.commaserver.service.dto.SearchConditionRequest;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 @Service
 public class SearchService {
 
-    public List<CommaDetailResponse> readUsingDate(String date) {
+    public List<CommaDetailResponse> searchByCondition(SearchConditionRequest searchConditionRequest) {
         return null;
     }
 }

--- a/src/main/java/commaproject/be/commaserver/service/dto/SearchConditionRequest.java
+++ b/src/main/java/commaproject/be/commaserver/service/dto/SearchConditionRequest.java
@@ -1,0 +1,14 @@
+package commaproject.be.commaserver.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class SearchConditionRequest {
+
+    private String date;
+    private String username;
+}

--- a/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
@@ -43,7 +43,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @ExtendWith({RestDocumentationExtension.class})
 @WebMvcTest(CommaController.class)
-가class CommaControllerTest {
+class CommaControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/comma/CommaControllerTest.java
@@ -43,8 +43,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 @ExtendWith({RestDocumentationExtension.class})
 @WebMvcTest(CommaController.class)
-@DisplayName("API /api/commas/* 컨트롤러 계층 단위 테스트")
-class CommaControllerTest {
+가class CommaControllerTest {
 
     @Autowired
     private MockMvc mockMvc;

--- a/src/test/java/commaproject/be/commaserver/controller/SearchControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/controller/SearchControllerTest.java
@@ -16,6 +16,7 @@ import commaproject.be.commaserver.common.BaseResponse;
 import commaproject.be.commaserver.service.SearchService;
 import commaproject.be.commaserver.service.dto.CommaDetailResponse;
 import commaproject.be.commaserver.service.dto.CommentResponse;
+import commaproject.be.commaserver.service.dto.SearchConditionRequest;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,6 +60,115 @@ class SearchControllerTest {
             .build();
     }
 
+    @DisplayName("특정 날짜, 특정 유저가 쓴 글 조회 성공")
+    @Test
+    void read_search_date_user() throws Exception {
+
+        // given
+        List<CommaDetailResponse> commaDetailResponses = createTestData();
+
+        BaseResponse<List<CommaDetailResponse>> baseResponse = new BaseResponse<>("200", "OK",
+            commaDetailResponses);
+
+        String date = "20221228";
+        String username = "donggi";
+        SearchConditionRequest searchConditionRequest = new SearchConditionRequest(date, username);
+
+        when(searchService.searchByCondition(searchConditionRequest)).thenReturn(commaDetailResponses);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/commas")
+                .queryParam("date", searchConditionRequest.getDate())
+                .queryParam("username", searchConditionRequest.getUsername())
+                .content(objectMapper
+                    .registerModule(new JavaTimeModule())
+                    .writeValueAsString(baseResponse))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "read-search-date-user",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("회고 아이디"),
+                        fieldWithPath("data[].title").type(JsonFieldType.STRING).description("회고 제목"),
+                        fieldWithPath("data[].content").type(JsonFieldType.STRING).description("회고 내용"),
+                        fieldWithPath("data[].username").type(JsonFieldType.STRING).description("회고 작성자"),
+                        fieldWithPath("data[].userId").type(JsonFieldType.NUMBER).description("회고 작성자 아이디"),
+                        fieldWithPath("data[].likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                        fieldWithPath("data[].createdAt").type(JsonFieldType.STRING).description("회고 작성된 시간"),
+                        fieldWithPath("data[].comments[].id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
+                        fieldWithPath("data[].comments[].username").type(JsonFieldType.STRING).description("댓글 작성자"),
+                        fieldWithPath("data[].comments[].userId").type(JsonFieldType.NUMBER).description("댓글 작성자 아이디"),
+                        fieldWithPath("data[].comments[].content").type(JsonFieldType.STRING).description("댓글 내용")
+                    )
+                )
+            );
+    }
+
+    @DisplayName("특정 사용자가 쓴 글 조회 성공")
+    @Test
+    void read_search_user() throws Exception {
+
+        // given
+        List<CommaDetailResponse> commaDetailResponses = createTestData();
+
+        BaseResponse<List<CommaDetailResponse>> baseResponse = new BaseResponse<>("200", "OK",
+            commaDetailResponses);
+
+        String date = null;
+        String username = "donggi";
+        SearchConditionRequest searchConditionRequest = new SearchConditionRequest(date, username);
+
+        when(searchService.searchByCondition(searchConditionRequest)).thenReturn(commaDetailResponses);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/commas")
+                .queryParam("username", searchConditionRequest.getUsername())
+                .content(objectMapper
+                    .registerModule(new JavaTimeModule())
+                    .writeValueAsString(baseResponse))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "read-search-user",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("회고 아이디"),
+                        fieldWithPath("data[].title").type(JsonFieldType.STRING).description("회고 제목"),
+                        fieldWithPath("data[].content").type(JsonFieldType.STRING).description("회고 내용"),
+                        fieldWithPath("data[].username").type(JsonFieldType.STRING).description("회고 작성자"),
+                        fieldWithPath("data[].userId").type(JsonFieldType.NUMBER).description("회고 작성자 아이디"),
+                        fieldWithPath("data[].likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                        fieldWithPath("data[].createdAt").type(JsonFieldType.STRING).description("회고 작성된 시간"),
+                        fieldWithPath("data[].comments[].id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
+                        fieldWithPath("data[].comments[].username").type(JsonFieldType.STRING).description("댓글 작성자"),
+                        fieldWithPath("data[].comments[].userId").type(JsonFieldType.NUMBER).description("댓글 작성자 아이디"),
+                        fieldWithPath("data[].comments[].content").type(JsonFieldType.STRING).description("댓글 내용")
+                    )
+                )
+            );
+    }
+
     @DisplayName("특정 날짜에 쓴 글 조회 성공")
     @Test
     void read_search_date() throws Exception {
@@ -70,13 +180,15 @@ class SearchControllerTest {
             commaDetailResponses);
 
         String date = "20221228";
+        String username = null;
+        SearchConditionRequest searchConditionRequest = new SearchConditionRequest(date, username);
 
-        when(searchService.readUsingDate(date)).thenReturn(commaDetailResponses);
+        when(searchService.searchByCondition(searchConditionRequest)).thenReturn(commaDetailResponses);
 
         // when
         ResultActions result = mockMvc.perform(
             RestDocumentationRequestBuilders.get("/api/commas")
-                .queryParam("date", date)
+                .queryParam("date", searchConditionRequest.getDate())
                 .content(objectMapper
                     .registerModule(new JavaTimeModule())
                     .writeValueAsString(baseResponse))
@@ -110,6 +222,8 @@ class SearchControllerTest {
                 )
             );
     }
+
+
 
 
     private List<CommaDetailResponse> createTestData() {

--- a/src/test/java/commaproject/be/commaserver/controller/SearchControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/controller/SearchControllerTest.java
@@ -1,0 +1,145 @@
+package commaproject.be.commaserver.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import commaproject.be.commaserver.common.BaseResponse;
+import commaproject.be.commaserver.service.SearchService;
+import commaproject.be.commaserver.service.dto.CommaDetailResponse;
+import commaproject.be.commaserver.service.dto.CommentResponse;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith({RestDocumentationExtension.class})
+@WebMvcTest(SearchController.class)
+class SearchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private SearchService searchService;
+
+    @BeforeEach
+    public void setUp(WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(documentationConfiguration(restDocumentation))
+            .alwaysDo(document("{method-name}",
+                preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
+            .build();
+    }
+
+    @DisplayName("특정 날짜에 쓴 글 조회 성공")
+    @Test
+    void read_search_date() throws Exception {
+
+        // given
+        List<CommaDetailResponse> commaDetailResponses = createTestData();
+
+        BaseResponse<List<CommaDetailResponse>> baseResponse = new BaseResponse<>("200", "OK",
+            commaDetailResponses);
+
+        String date = "20221228";
+
+        when(searchService.readUsingDate(date)).thenReturn(commaDetailResponses);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.get("/api/commas")
+                .queryParam("date", date)
+                .content(objectMapper
+                    .registerModule(new JavaTimeModule())
+                    .writeValueAsString(baseResponse))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "read-search-date",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("회고 아이디"),
+                        fieldWithPath("data[].title").type(JsonFieldType.STRING).description("회고 제목"),
+                        fieldWithPath("data[].content").type(JsonFieldType.STRING).description("회고 내용"),
+                        fieldWithPath("data[].username").type(JsonFieldType.STRING).description("회고 작성자"),
+                        fieldWithPath("data[].userId").type(JsonFieldType.NUMBER).description("회고 작성자 아이디"),
+                        fieldWithPath("data[].likeCount").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+                        fieldWithPath("data[].createdAt").type(JsonFieldType.STRING).description("회고 작성된 시간"),
+                        fieldWithPath("data[].comments[].id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
+                        fieldWithPath("data[].comments[].username").type(JsonFieldType.STRING).description("댓글 작성자"),
+                        fieldWithPath("data[].comments[].userId").type(JsonFieldType.NUMBER).description("댓글 작성자 아이디"),
+                        fieldWithPath("data[].comments[].content").type(JsonFieldType.STRING).description("댓글 내용")
+                    )
+                )
+            );
+    }
+
+
+    private List<CommaDetailResponse> createTestData() {
+        List<CommentResponse> comments1 = new ArrayList<>();
+        comments1.add(new CommentResponse(1L, "username1", 1L, "content1"));
+        Long commaId1 = 1L;
+
+        CommaDetailResponse commaDetailResponse1 = new CommaDetailResponse(
+            commaId1, "title1", "content1", "username1", 1L, LocalDateTime.of(2022, 12, 27, 15, 13),2, comments1);
+
+
+        List<CommentResponse> comments2 = new ArrayList<>();
+        comments2.add(new CommentResponse(2L, "username2", 2L, "content2"));
+        Long commaId2 = 2L;
+
+        CommaDetailResponse commaDetailResponse2 = new CommaDetailResponse(
+            commaId2, "title2", "content2", "username2", 2L, LocalDateTime.of(2022, 12, 28, 15, 13),3, comments2);
+
+        List<CommentResponse> comments3 = new ArrayList<>();
+        comments3.add(new CommentResponse(3L, "username3", 3L, "content3"));
+        Long commaId3 = 3L;
+
+        CommaDetailResponse commaDetailResponse3 = new CommaDetailResponse(
+            commaId3, "title3", "content3", "username3", 3L, LocalDateTime.of(2022, 12, 28, 15, 14),3, comments3);
+
+
+        List<CommaDetailResponse> commaDetailResponses = new ArrayList<>();
+        commaDetailResponses.add(commaDetailResponse1);
+        commaDetailResponses.add(commaDetailResponse2);
+        commaDetailResponses.add(commaDetailResponse3);
+        return commaDetailResponses;
+    }
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #16 


<br><br>

### 📝 구현 내용

- 쿼리 파람으로 검색 조건을 받아 데이터 반환하는 API 컨트롤러 추가
  - `username`, `date`, `username 과 date` 검색 조건에 따른 RestDocs 테스트 추가
- 여러 개의 `Query Parameter` 를 받기 위해 `SearchConditionRequest` 라는 `DTO` 클래스 추가

<br><br>
