### PR TITLE
댓글 삭제 컨트롤러 메서드, RestDocs 테스트 추가

### DIFF
--- a/src/main/java/commaproject/be/commaserver/controller/CommentController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/CommentController.java
@@ -6,6 +6,7 @@ import commaproject.be.commaserver.service.dto.CommentDetailResponse;
 import commaproject.be.commaserver.service.dto.CommentRequest;
 import commaproject.be.commaserver.service.dto.CommentResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -28,5 +29,11 @@ public class CommentController {
     public BaseResponse<CommentDetailResponse> update(@PathVariable Long commaId, @PathVariable Long commentId, @RequestBody CommentRequest commentRequest) {
         CommentDetailResponse commentDetailResponse = commentService.update(commaId, commentId, commentRequest);
         return new BaseResponse<>("200", "OK", commentDetailResponse);
+    }
+
+    @DeleteMapping("/api/commas/{commaId}/comments/{commentId}")
+    public BaseResponse<CommentResponse> delete(@PathVariable Long commaId, @PathVariable Long commentId) {
+        CommentResponse commentResponse = commentService.delete(commaId, commentId);
+        return new BaseResponse<>("200", "OK", commentResponse);
     }
 }

--- a/src/main/java/commaproject/be/commaserver/service/CommentService.java
+++ b/src/main/java/commaproject/be/commaserver/service/CommentService.java
@@ -15,4 +15,8 @@ public class CommentService {
     public CommentDetailResponse update(Long commaId, Long commentId, CommentRequest commentRequest) {
         return null;
     }
+
+    public CommentResponse delete(Long commaId, Long commentId) {
+        return null;
+    }
 }

--- a/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
@@ -71,7 +71,7 @@ class CommentControllerTest {
 
         // when
         ResultActions result = mockMvc.perform(
-            RestDocumentationRequestBuilders.post("/api/commas/{commaId}", commaId)
+            RestDocumentationRequestBuilders.post("/api/commas/{commaId}/comments", commaId)
                 .content(objectMapper
                     .writeValueAsString(commentRequest))
                 .contentType(MediaType.APPLICATION_JSON)
@@ -85,6 +85,9 @@ class CommentControllerTest {
                     "create-comment",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("commaId").description("생성할 댓글이 있는 회고 아이디")
+                    ),
                     responseFields(
                         fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -126,11 +129,15 @@ class CommentControllerTest {
                     "update-comment",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("commaId").description("수정할 댓글이 있는 회고 아이디"),
+                        parameterWithName("commentId").description("수정할 댓글 아이디")
+                    ),
                     responseFields(
                         fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
-                        fieldWithPath("data.usernamex").type(JsonFieldType.STRING).description("수정한 작성자 닉네임"),
+                        fieldWithPath("data.username").type(JsonFieldType.STRING).description("수정한 작성자 닉네임"),
                         fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("수정한 작성자 아이디"),
                         fieldWithPath("data.content").type(JsonFieldType.STRING).description("수정된 댓글 내용")
                     )

--- a/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -131,6 +133,43 @@ class CommentControllerTest {
                         fieldWithPath("data.usernamex").type(JsonFieldType.STRING).description("수정한 작성자 닉네임"),
                         fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("수정한 작성자 아이디"),
                         fieldWithPath("data.content").type(JsonFieldType.STRING).description("수정된 댓글 내용")
+                    )
+                ));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 성공")
+    void delete_comment_success() throws Exception {
+
+        // given
+        Long commaId = 1L;
+        Long commentId = 1L;
+        CommentResponse commentResponse = new CommentResponse(commentId);
+
+        when(commentService.delete(commaId, commentId)).thenReturn(commentResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.delete("/api/commas/{commaId}/comments/{commentId}", commaId, commentId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "delete-comment",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("commaId").description("삭제할 댓글이 있는 회고 아이디"),
+                        parameterWithName("commentId").description("삭제할 댓글 아이디")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("삭제된 댓글 아이디")
                     )
                 ));
     }


### PR DESCRIPTION
### 📝 구현 내용

- 댓글 삭제 컨트롤러 메서드 추가
- RestDocs 테스트 추가
- `Comment` restdocs 문서에 `pathParameter` 추가
