### PR TITLE
댓글 API 컨트롤러, RestDocs 테스트 추가

### DIFF
--- a/src/main/java/commaproject/be/commaserver/controller/CommaController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/CommaController.java
@@ -34,7 +34,7 @@ public class CommaController {
     }
 
     @PostMapping("/api/commas")
-    public BaseResponse<CommaResponse> update(@RequestBody CommaRequest commaRequest) {
+    public BaseResponse<CommaResponse> create(@RequestBody CommaRequest commaRequest) {
         CommaResponse commaResponse = commaService.create(commaRequest);
         return new BaseResponse<>("200", "OK", commaResponse);
     }

--- a/src/main/java/commaproject/be/commaserver/controller/CommentController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/CommentController.java
@@ -1,0 +1,24 @@
+package commaproject.be.commaserver.controller;
+
+import commaproject.be.commaserver.common.BaseResponse;
+import commaproject.be.commaserver.service.CommentService;
+import commaproject.be.commaserver.service.dto.CommentRequest;
+import commaproject.be.commaserver.service.dto.CommentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/api/commas/{commaId}")
+    public BaseResponse<CommentResponse> create(@PathVariable Long commaId, @RequestBody CommentRequest commentRequest) {
+        CommentResponse commentResponse = commentService.create(commaId, commentRequest);
+        return new BaseResponse<>("200", "OK", commentResponse);
+    }
+}

--- a/src/main/java/commaproject/be/commaserver/controller/CommentController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/CommentController.java
@@ -2,11 +2,13 @@ package commaproject.be.commaserver.controller;
 
 import commaproject.be.commaserver.common.BaseResponse;
 import commaproject.be.commaserver.service.CommentService;
+import commaproject.be.commaserver.service.dto.CommentDetailResponse;
 import commaproject.be.commaserver.service.dto.CommentRequest;
 import commaproject.be.commaserver.service.dto.CommentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,9 +18,15 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("/api/commas/{commaId}")
+    @PostMapping("/api/commas/{commaId}/comments")
     public BaseResponse<CommentResponse> create(@PathVariable Long commaId, @RequestBody CommentRequest commentRequest) {
         CommentResponse commentResponse = commentService.create(commaId, commentRequest);
         return new BaseResponse<>("200", "OK", commentResponse);
+    }
+
+    @PutMapping("/api/commas/{commaId}/comments/{commentId}")
+    public BaseResponse<CommentDetailResponse> update(@PathVariable Long commaId, @PathVariable Long commentId, @RequestBody CommentRequest commentRequest) {
+        CommentDetailResponse commentDetailResponse = commentService.update(commaId, commentId, commentRequest);
+        return new BaseResponse<>("200", "OK", commentDetailResponse);
     }
 }

--- a/src/main/java/commaproject/be/commaserver/controller/CommentController.java
+++ b/src/main/java/commaproject/be/commaserver/controller/CommentController.java
@@ -6,6 +6,7 @@ import commaproject.be.commaserver.service.dto.CommentDetailResponse;
 import commaproject.be.commaserver.service.dto.CommentRequest;
 import commaproject.be.commaserver.service.dto.CommentResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -28,5 +29,11 @@ public class CommentController {
     public BaseResponse<CommentDetailResponse> update(@PathVariable Long commaId, @PathVariable Long commentId, @RequestBody CommentRequest commentRequest) {
         CommentDetailResponse commentDetailResponse = commentService.update(commaId, commentId, commentRequest);
         return new BaseResponse<>("200", "OK", commentDetailResponse);
+    }
+
+    @DeleteMapping("/api/commas/{commaId}/comments/{commentId}")
+    public BaseResponse<CommentResponse> delete(@PathVariable Long commaId, @PathVariable Long commentId) {
+        CommentResponse commentResponse = commentService.delete(commaId, commentId);
+        return new BaseResponse<>("200", "OK", commentResponse);
     }
 }

--- a/src/main/java/commaproject/be/commaserver/service/CommentService.java
+++ b/src/main/java/commaproject/be/commaserver/service/CommentService.java
@@ -1,0 +1,13 @@
+package commaproject.be.commaserver.service;
+
+import commaproject.be.commaserver.service.dto.CommentRequest;
+import commaproject.be.commaserver.service.dto.CommentResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommentService {
+
+    public CommentResponse create(Long commaId, CommentRequest commentRequest) {
+        return null;
+    }
+}

--- a/src/main/java/commaproject/be/commaserver/service/CommentService.java
+++ b/src/main/java/commaproject/be/commaserver/service/CommentService.java
@@ -1,5 +1,6 @@
 package commaproject.be.commaserver.service;
 
+import commaproject.be.commaserver.service.dto.CommentDetailResponse;
 import commaproject.be.commaserver.service.dto.CommentRequest;
 import commaproject.be.commaserver.service.dto.CommentResponse;
 import org.springframework.stereotype.Service;
@@ -8,6 +9,10 @@ import org.springframework.stereotype.Service;
 public class CommentService {
 
     public CommentResponse create(Long commaId, CommentRequest commentRequest) {
+        return null;
+    }
+
+    public CommentDetailResponse update(Long commaId, Long commentId, CommentRequest commentRequest) {
         return null;
     }
 }

--- a/src/main/java/commaproject/be/commaserver/service/CommentService.java
+++ b/src/main/java/commaproject/be/commaserver/service/CommentService.java
@@ -15,4 +15,8 @@ public class CommentService {
     public CommentDetailResponse update(Long commaId, Long commentId, CommentRequest commentRequest) {
         return null;
     }
+
+    public CommentResponse delete(Long commaId, Long commentId) {
+        return null;
+    }
 }

--- a/src/main/java/commaproject/be/commaserver/service/dto/CommaDetailResponse.java
+++ b/src/main/java/commaproject/be/commaserver/service/dto/CommaDetailResponse.java
@@ -16,6 +16,6 @@ public class CommaDetailResponse {
     private Long userId;
     private LocalDateTime createdAt;
     private int likeCount;
-    private List<CommentResponse> comments;
+    private List<CommentDetailResponse> comments;
 
 }

--- a/src/main/java/commaproject/be/commaserver/service/dto/CommentDetailResponse.java
+++ b/src/main/java/commaproject/be/commaserver/service/dto/CommentDetailResponse.java
@@ -5,7 +5,10 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CommentResponse {
+public class CommentDetailResponse {
 
     private Long id;
+    private String username;
+    private Long userId;
+    private String content;
 }

--- a/src/main/java/commaproject/be/commaserver/service/dto/CommentRequest.java
+++ b/src/main/java/commaproject/be/commaserver/service/dto/CommentRequest.java
@@ -1,0 +1,18 @@
+package commaproject.be.commaserver.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class CommentRequest {
+
+    private Long commaId;
+    private String content;
+    private String username;
+    private Long userId;
+}

--- a/src/test/java/commaproject/be/commaserver/controller/CommaControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/controller/CommaControllerTest.java
@@ -1,4 +1,4 @@
-package commaproject.be.commaserver.comma;
+package commaproject.be.commaserver.controller;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -15,12 +15,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import commaproject.be.commaserver.common.BaseResponse;
-import commaproject.be.commaserver.controller.CommaController;
 import commaproject.be.commaserver.service.CommaService;
 import commaproject.be.commaserver.service.dto.CommaDetailResponse;
 import commaproject.be.commaserver.service.dto.CommaRequest;
-import commaproject.be.commaserver.service.dto.CommentResponse;
 import commaproject.be.commaserver.service.dto.CommaResponse;
+import commaproject.be.commaserver.service.dto.CommentDetailResponse;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,8 +69,8 @@ class CommaControllerTest {
     void read_comma_success() throws Exception {
 
         // given
-        List<CommentResponse> comments = new ArrayList<>();
-        comments.add(new CommentResponse(1L, "username1", 1L, "content1"));
+        List<CommentDetailResponse> comments = new ArrayList<>();
+        comments.add(new CommentDetailResponse(1L, "username1", 1L, "content1"));
         Long commaId = 1L;
         CommaDetailResponse commaDetailResponse = new CommaDetailResponse(
             commaId, "title1", "content1", "username1", 1L, LocalDateTime.of(2022, 12, 27, 15, 13),1, comments);
@@ -172,10 +171,11 @@ class CommaControllerTest {
 
         // given
         Long userId = 1L;
+        Long commaId = 1L;
         CommaRequest commaRequest = new CommaRequest("title1", "content1", "username1", userId);
-        CommaResponse createResponse = new CommaResponse(commaRequest.getUserId());
+        CommaResponse commaResponse = new CommaResponse(commaId);
 
-        when(commaService.create(commaRequest)).thenReturn(createResponse);
+        when(commaService.create(commaRequest)).thenReturn(commaResponse);
 
         // when
         ResultActions result = mockMvc.perform(
@@ -211,8 +211,8 @@ class CommaControllerTest {
         Long userId = 1L;
         CommaRequest commaRequest = new CommaRequest("title1", "content1", "username1", userId);
 
-        List<CommentResponse> comments = new ArrayList<>();
-        comments.add(new CommentResponse(1L, "username1", 1L, "content1"));
+        List<CommentDetailResponse> comments = new ArrayList<>();
+        comments.add(new CommentDetailResponse(1L, "username1", 1L, "content1"));
 
         CommaDetailResponse commaDetailResponse = new CommaDetailResponse(commaId, "title1", "content1", "username1", userId, LocalDateTime.of(2022, 12, 28, 15, 30), 1, comments);
 
@@ -292,16 +292,16 @@ class CommaControllerTest {
     }
 
     private List<CommaDetailResponse> createTestData() {
-        List<CommentResponse> comments1 = new ArrayList<>();
-        comments1.add(new CommentResponse(1L, "username1", 1L, "content1"));
+        List<CommentDetailResponse> comments1 = new ArrayList<>();
+        comments1.add(new CommentDetailResponse(1L, "username1", 1L, "content1"));
         Long commaId1 = 1L;
 
         CommaDetailResponse commaDetailResponse1 = new CommaDetailResponse(
             commaId1, "title1", "content1", "username1", 1L, LocalDateTime.of(2022, 12, 27, 15, 13),2, comments1);
 
 
-        List<CommentResponse> comments2 = new ArrayList<>();
-        comments2.add(new CommentResponse(2L, "username2", 2L, "content2"));
+        List<CommentDetailResponse> comments2 = new ArrayList<>();
+        comments2.add(new CommentDetailResponse(2L, "username2", 2L, "content2"));
         Long commaId2 = 2L;
 
         CommaDetailResponse commaDetailResponse2 = new CommaDetailResponse(

--- a/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import commaproject.be.commaserver.service.CommentService;
+import commaproject.be.commaserver.service.dto.CommentDetailResponse;
 import commaproject.be.commaserver.service.dto.CommentRequest;
 import commaproject.be.commaserver.service.dto.CommentResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,6 +87,50 @@ class CommentControllerTest {
                         fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("생성된 댓글 아이디")
+                    )
+                ));
+    }
+
+    @Test
+    @DisplayName("댓글 수정 성공")
+    void update_comment_success() throws Exception {
+
+        // given
+        Long commaId = 1L;
+        Long commentId = 1L;
+        CommentRequest commentRequest = new CommentRequest(commaId, "댓글 본문1", "username1", 1L);
+        CommentDetailResponse commentDetailResponse = new CommentDetailResponse(
+            commentId,
+            commentRequest.getUsername(),
+            commentRequest.getUserId(),
+            commentRequest.getContent()
+        );
+
+        when(commentService.update(commaId, commentId, commentRequest)).thenReturn(commentDetailResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.put("/api/commas/{commaId}/comments/{commentId}", commaId, commentId)
+                .content(objectMapper
+                    .writeValueAsString(commentRequest))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "update-comment",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
+                        fieldWithPath("data.usernamex").type(JsonFieldType.STRING).description("수정한 작성자 닉네임"),
+                        fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("수정한 작성자 아이디"),
+                        fieldWithPath("data.content").type(JsonFieldType.STRING).description("수정된 댓글 내용")
                     )
                 ));
     }

--- a/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
@@ -1,0 +1,92 @@
+package commaproject.be.commaserver.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import commaproject.be.commaserver.service.CommentService;
+import commaproject.be.commaserver.service.dto.CommentRequest;
+import commaproject.be.commaserver.service.dto.CommentResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@ExtendWith({RestDocumentationExtension.class})
+@WebMvcTest(CommentController.class)
+class CommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CommentService commentService;
+
+    @BeforeEach
+    public void setUp(WebApplicationContext webApplicationContext,
+        RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+            .apply(documentationConfiguration(restDocumentation))
+            .alwaysDo(document("{method-name}",
+                preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint())))
+            .build();
+    }
+
+    @Test
+    @DisplayName("댓글 생성 성공")
+    void create_comment_success() throws Exception {
+
+        // given
+        Long commaId = 1L;
+        Long commentId = 1L;
+        CommentRequest commentRequest = new CommentRequest(commaId, "댓글 본문1", "username1", 1L);
+        CommentResponse commentResponse = new CommentResponse(commentId);
+
+        when(commentService.create(commaId, commentRequest)).thenReturn(commentResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.post("/api/commas/{commaId}", commaId)
+                .content(objectMapper
+                    .writeValueAsString(commentRequest))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "create-comment",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("생성된 댓글 아이디")
+                    )
+                ));
+    }
+}

--- a/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/controller/CommentControllerTest.java
@@ -8,6 +8,8 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -69,7 +71,7 @@ class CommentControllerTest {
 
         // when
         ResultActions result = mockMvc.perform(
-            RestDocumentationRequestBuilders.post("/api/commas/{commaId}", commaId)
+            RestDocumentationRequestBuilders.post("/api/commas/{commaId}/comments", commaId)
                 .content(objectMapper
                     .writeValueAsString(commentRequest))
                 .contentType(MediaType.APPLICATION_JSON)
@@ -83,6 +85,9 @@ class CommentControllerTest {
                     "create-comment",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("commaId").description("생성할 댓글이 있는 회고 아이디")
+                    ),
                     responseFields(
                         fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
@@ -124,13 +129,54 @@ class CommentControllerTest {
                     "update-comment",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("commaId").description("수정할 댓글이 있는 회고 아이디"),
+                        parameterWithName("commentId").description("수정할 댓글 아이디")
+                    ),
                     responseFields(
                         fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
                         fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                         fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("댓글 아이디"),
-                        fieldWithPath("data.usernamex").type(JsonFieldType.STRING).description("수정한 작성자 닉네임"),
+                        fieldWithPath("data.username").type(JsonFieldType.STRING).description("수정한 작성자 닉네임"),
                         fieldWithPath("data.userId").type(JsonFieldType.NUMBER).description("수정한 작성자 아이디"),
                         fieldWithPath("data.content").type(JsonFieldType.STRING).description("수정된 댓글 내용")
+                    )
+                ));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 성공")
+    void delete_comment_success() throws Exception {
+
+        // given
+        Long commaId = 1L;
+        Long commentId = 1L;
+        CommentResponse commentResponse = new CommentResponse(commentId);
+
+        when(commentService.delete(commaId, commentId)).thenReturn(commentResponse);
+
+        // when
+        ResultActions result = mockMvc.perform(
+            RestDocumentationRequestBuilders.delete("/api/commas/{commaId}/comments/{commentId}", commaId, commentId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result
+            .andExpect(status().isOk())
+            .andDo(
+                document(
+                    "delete-comment",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("commaId").description("삭제할 댓글이 있는 회고 아이디"),
+                        parameterWithName("commentId").description("삭제할 댓글 아이디")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("삭제된 댓글 아이디")
                     )
                 ));
     }

--- a/src/test/java/commaproject/be/commaserver/controller/SearchControllerTest.java
+++ b/src/test/java/commaproject/be/commaserver/controller/SearchControllerTest.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import commaproject.be.commaserver.common.BaseResponse;
 import commaproject.be.commaserver.service.SearchService;
 import commaproject.be.commaserver.service.dto.CommaDetailResponse;
-import commaproject.be.commaserver.service.dto.CommentResponse;
+import commaproject.be.commaserver.service.dto.CommentDetailResponse;
 import commaproject.be.commaserver.service.dto.SearchConditionRequest;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -227,23 +227,23 @@ class SearchControllerTest {
 
 
     private List<CommaDetailResponse> createTestData() {
-        List<CommentResponse> comments1 = new ArrayList<>();
-        comments1.add(new CommentResponse(1L, "username1", 1L, "content1"));
+        List<CommentDetailResponse> comments1 = new ArrayList<>();
+        comments1.add(new CommentDetailResponse(1L, "username1", 1L, "content1"));
         Long commaId1 = 1L;
 
         CommaDetailResponse commaDetailResponse1 = new CommaDetailResponse(
             commaId1, "title1", "content1", "username1", 1L, LocalDateTime.of(2022, 12, 27, 15, 13),2, comments1);
 
 
-        List<CommentResponse> comments2 = new ArrayList<>();
-        comments2.add(new CommentResponse(2L, "username2", 2L, "content2"));
+        List<CommentDetailResponse> comments2 = new ArrayList<>();
+        comments2.add(new CommentDetailResponse(2L, "username2", 2L, "content2"));
         Long commaId2 = 2L;
 
         CommaDetailResponse commaDetailResponse2 = new CommaDetailResponse(
             commaId2, "title2", "content2", "username2", 2L, LocalDateTime.of(2022, 12, 28, 15, 13),3, comments2);
 
-        List<CommentResponse> comments3 = new ArrayList<>();
-        comments3.add(new CommentResponse(3L, "username3", 3L, "content3"));
+        List<CommentDetailResponse> comments3 = new ArrayList<>();
+        comments3.add(new CommentDetailResponse(3L, "username3", 3L, "content3"));
         Long commaId3 = 3L;
 
         CommaDetailResponse commaDetailResponse3 = new CommaDetailResponse(


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #18 


<br><br>

### 📝 구현 내용

- 댓글 생성 API 추가
- 댓글 수정 API 추가
- 댓글 삭제 API 추가
- API RestDocs 테스트 추가

<br><br>

### 💡 참고 자료

<img width="371" alt="Screen Shot 2023-01-05 at 5 29 20 PM" src="https://user-images.githubusercontent.com/73376468/210735377-f00d61d6-4ccd-465f-a30b-32ffb579a3fe.png">

