### PR TITLE
GitHub Actions CI 설정, Spring 실행 환경 분리, 테스트 수정

### DIFF
--- a/.github/workflow/CI-BE.yml
+++ b/.github/workflow/CI-BE.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - be
-    pull_request:
+  pull_request:
+    branches:
       - be
-    permissions:
-      contents: read
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflow/CI-BE.yml
+++ b/.github/workflow/CI-BE.yml
@@ -1,0 +1,40 @@
+name: CI - BE
+
+on:
+  push:
+    branches:
+      - be
+    pull_request:
+      - be
+    permissions:
+      contents: read
+
+jobs:
+  build:
+    name: SpringBoot Test
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+      - name: Use Gradle Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Grant Execute Permission For Gradlew
+        run: chmod +x gradlew
+
+      - name: Test With Gradle
+        run: ./gradlew test

--- a/.github/workflow/CI-BE.yml
+++ b/.github/workflow/CI-BE.yml
@@ -5,8 +5,13 @@ on:
     branches:
       - be
   pull_request:
-    branches:
-      - be
+    branches: [ be ]
+    paths:
+      [
+        "src/**",
+        "build.gradle",
+      ]
+    types: [ opened, synchronize, reopened ]
 
 permissions:
   contents: read

--- a/src/main/java/commaproject/be/commaserver/service/LoginService.java
+++ b/src/main/java/commaproject/be/commaserver/service/LoginService.java
@@ -22,7 +22,7 @@ public class LoginService {
 
         User user = userRepository.findByEmail(userInformation.getEmail())
             .orElseGet(() -> userRepository.save(User.from(userInformation.getUsername(),
-                userInformation.getEmail(), userInformation.getUserImageUri())));
+                userInformation.getEmail(), userInformation.getImages())));
 
         String accessToken = jwtProvider.generateAccessToken(user.getId());
         String refreshToken = jwtProvider.generateRefreshToken(user.getId());

--- a/src/main/java/commaproject/be/commaserver/service/OauthService.java
+++ b/src/main/java/commaproject/be/commaserver/service/OauthService.java
@@ -27,8 +27,6 @@ public class OauthService {
         );
 
         String authorizationHeader = getAuthorizationHeader(oauthTokenResponse);
-        System.out.println("======= authorizationHeader : " + authorizationHeader);
-
         return oauthApiClient.getUserInformation(authorizationHeader);
     }
 

--- a/src/main/java/commaproject/be/commaserver/service/dto/UserInformation.java
+++ b/src/main/java/commaproject/be/commaserver/service/dto/UserInformation.java
@@ -9,5 +9,5 @@ public class UserInformation {
 
     private String username;
     private String email;
-    private String userImageUri;
+    private String images;
 }

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -1,0 +1,29 @@
+spring:
+
+  config:
+    activate:
+      on-profile: local-db
+
+  sql:
+    init:
+      mode: always
+
+  datasource:
+    driverClassName: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/comma
+    username: donggi
+    password: '0408'
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+
+    defer-datasource-initialization: true
+
+    properties:
+      hibernate:
+        format_sql: true
+        show-sql: true
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,28 +1,10 @@
 spring:
-
-  config:
-    import: application-auth.yml
-
-  sql:
-    init:
-      mode: always
-
-  datasource:
-    driverClassName: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/comma
-    username: donggi
-    password: '0408'
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-
-    defer-datasource-initialization: true
-
-    properties:
-      hibernate:
-        format_sql: true
-        show-sql: true
-
+  profiles:
+    active:
+      - local
+    group:
+      local: "local-db, local-auth"
+      test: "test-auth"
+    include:
+      - auth
+      - db

--- a/src/test/java/commaproject/be/commaserver/integration/auth/OauthLoginIntegrationTest.java
+++ b/src/test/java/commaproject/be/commaserver/integration/auth/OauthLoginIntegrationTest.java
@@ -5,9 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import commaproject.be.commaserver.service.LoginService;
-import commaproject.be.commaserver.service.OauthService;
 import commaproject.be.commaserver.service.dto.LoginInformation;
-import commaproject.be.commaserver.service.dto.UserInformation;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,8 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
+@ActiveProfiles("test")
 @AutoConfigureWireMock(port = 0)
 @TestPropertySource(properties = {
     "kakao.access-token-uri=http://localhost:${wiremock.server.port}",
@@ -24,9 +24,6 @@ import org.springframework.test.context.TestPropertySource;
 })
 @SpringBootTest
 public class OauthLoginIntegrationTest {
-
-    @Autowired
-    private OauthService oauthService;
 
     @Autowired
     private LoginService loginService;
@@ -39,12 +36,13 @@ public class OauthLoginIntegrationTest {
     @Test
     @DisplayName("인가 코드로 auth 서버에서 유저 정보를 가져와 UserRepository에 유저를 저장하고 로그인에 성공한다")
     void oauth_login_success() {
-        WireMock.setScenarioState("Email Not Null", "Started");
+        WireMock.setScenarioState("OAuth Login", "Started");
 
-        UserInformation userInformation = oauthService.oauth("code");
         LoginInformation loginInformation = loginService.login("code");
 
-        assertThat(userInformation).isNotNull();
-        assertThat(loginInformation).isNotNull();
+        assertThat(loginInformation.getUserId()).isEqualTo(1);
+        assertThat(loginInformation.getUsername()).isEqualTo("donggi");
+        assertThat(loginInformation.getUserImageUri()).isEqualTo("http://yyy.kakaoo.com/img_110x110.jpg");
+        assertThat(loginInformation.getEmail()).isEqualTo("donggi@kakao.com");
     }
 }

--- a/src/test/java/commaproject/be/commaserver/integration/auth/stub/OAuthMocks.java
+++ b/src/test/java/commaproject/be/commaserver/integration/auth/stub/OAuthMocks.java
@@ -34,7 +34,7 @@ public class OAuthMocks {
 
     public static void setupMockUserInformationResponse() throws IOException {
         stubFor(get(urlEqualTo("/v2/user/me"))
-            .inScenario("Email Not Null")
+            .inScenario("OAuth Login")
             .whenScenarioStateIs(STARTED)
             .withHeader("Authorization", equalTo("bearer accessToken"))
             .willReturn(aResponse()

--- a/src/test/java/commaproject/be/commaserver/service/CommaServiceTest.java
+++ b/src/test/java/commaproject/be/commaserver/service/CommaServiceTest.java
@@ -110,7 +110,7 @@ class CommaServiceTest {
         CommaResponse removeComma = commaService.remove(commaId);
 
         // then
-        verify(commaRepository).delete(comma.get());
+        verify(commaRepository, times(1)).delete(comma.get());
         assertThat(removeComma).isNotNull();
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,0 @@
-spring:
-
-  config:
-    import: application-auth-test.yml

--- a/src/test/resources/payload/oauth-login-response.json
+++ b/src/test/resources/payload/oauth-login-response.json
@@ -1,7 +1,7 @@
 {
   "user_id": 1,
   "username": "donggi",
-  "user_image_uri": "http://yyy.kakao.com/img_110x110.jpg",
+  "images": "http://yyy.kakaoo.com/img_110x110.jpg",
   "email": "donggi@kakao.com",
   "access_token": "accessToken",
   "refresh_token": "refreshToken"


### PR DESCRIPTION
### ❗️ 이슈 번호

Closes #31 


<br><br>

### 📝 구현 내용

- GitHub Actions CI 설정 추가
- Spring Profiles 를 이용하여 테스트, 개발 환경 분리
- 테스트코드 수정
  - verify() 검증시 times() 메서드를 이용하여 메서드 호출 횟수 검증하도록 변경
  - OAuth 통합테스트에서 로그인 정보를 받아올때 유저 이미지 주소를 받아올 수 있도록 변경 (역직렬화 문제가 있어 필드값 변경)

<br><br>

GitHub Action CI 설정과 Spring 환경 분리, 테스트코드 PR 리뷰 반영하였습니다!
이번 리뷰도 잘 부탁드리겠습니다!!

### 💡 참고 자료

**[테스트코드 결과]**

<img width="270" alt="Screen Shot 2023-02-04 at 5 46 18 PM" src="https://user-images.githubusercontent.com/73376468/216758065-3d00a2a0-852d-4aaa-bff7-9c43a3470edd.png">

